### PR TITLE
Project's folder opening, basic Settings and open by URL

### DIFF
--- a/CodeEdit.xcodeproj/project.pbxproj
+++ b/CodeEdit.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0468438527DC76E300F8E88E /* CodeEditorAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0468438427DC76E200F8E88E /* CodeEditorAppDelegate.swift */; };
+		04F2BF0F27DBB28E0024EAB1 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F2BF0E27DBB28E0024EAB1 /* SettingsView.swift */; };
+		04F2BF1227DBB3C10024EAB1 /* GeneralSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F2BF1127DBB3C10024EAB1 /* GeneralSettingsView.swift */; };
 		B658FB3027DA9E0F00EA4DBD /* CodeEditApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B658FB2F27DA9E0F00EA4DBD /* CodeEditApp.swift */; };
 		B658FB3227DA9E0F00EA4DBD /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B658FB3127DA9E0F00EA4DBD /* ContentView.swift */; };
 		B658FB3427DA9E1000EA4DBD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B658FB3327DA9E1000EA4DBD /* Assets.xcassets */; };
@@ -34,6 +37,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0468438427DC76E200F8E88E /* CodeEditorAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeEditorAppDelegate.swift; sourceTree = "<group>"; };
+		04F2BF0E27DBB28E0024EAB1 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		04F2BF1127DBB3C10024EAB1 /* GeneralSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsView.swift; sourceTree = "<group>"; };
 		B658FB2C27DA9E0F00EA4DBD /* CodeEdit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CodeEdit.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B658FB2F27DA9E0F00EA4DBD /* CodeEditApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeEditApp.swift; sourceTree = "<group>"; };
 		B658FB3127DA9E0F00EA4DBD /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -72,6 +78,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		04F2BF1027DBB3AF0024EAB1 /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				04F2BF0E27DBB28E0024EAB1 /* SettingsView.swift */,
+				04F2BF1127DBB3C10024EAB1 /* GeneralSettingsView.swift */,
+			);
+			path = Settings;
+			sourceTree = "<group>";
+		};
 		B658FB2327DA9E0F00EA4DBD = {
 			isa = PBXGroup;
 			children = (
@@ -95,11 +110,13 @@
 		B658FB2E27DA9E0F00EA4DBD /* CodeEdit */ = {
 			isa = PBXGroup;
 			children = (
+				04F2BF1027DBB3AF0024EAB1 /* Settings */,
 				B658FB2F27DA9E0F00EA4DBD /* CodeEditApp.swift */,
 				B658FB3127DA9E0F00EA4DBD /* ContentView.swift */,
 				B658FB3327DA9E1000EA4DBD /* Assets.xcassets */,
 				B658FB3827DA9E1000EA4DBD /* CodeEdit.entitlements */,
 				B658FB3527DA9E1000EA4DBD /* Preview Content */,
+				0468438427DC76E200F8E88E /* CodeEditorAppDelegate.swift */,
 			);
 			path = CodeEdit;
 			sourceTree = "<group>";
@@ -259,7 +276,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				04F2BF0F27DBB28E0024EAB1 /* SettingsView.swift in Sources */,
+				0468438527DC76E300F8E88E /* CodeEditorAppDelegate.swift in Sources */,
 				B658FB3227DA9E0F00EA4DBD /* ContentView.swift in Sources */,
+				04F2BF1227DBB3C10024EAB1 /* GeneralSettingsView.swift in Sources */,
 				B658FB3027DA9E0F00EA4DBD /* CodeEditApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -418,14 +438,16 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = CodeEdit/CodeEdit.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"CodeEdit/Preview Content\"";
-				DEVELOPMENT_TEAM = 9VS2VKC5LQ;
+				DEVELOPMENT_TEAM = 6M253KWXRJ;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = CodeEdit/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -434,6 +456,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = austincondiff.CodeEdit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 			};
@@ -445,14 +468,16 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = CodeEdit/CodeEdit.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"CodeEdit/Preview Content\"";
-				DEVELOPMENT_TEAM = 9VS2VKC5LQ;
+				DEVELOPMENT_TEAM = 6M253KWXRJ;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = CodeEdit/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -461,6 +486,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = austincondiff.CodeEdit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 			};

--- a/CodeEdit/CodeEditApp.swift
+++ b/CodeEdit/CodeEditApp.swift
@@ -9,11 +9,20 @@ import SwiftUI
 
 @main
 struct CodeEditApp: App {
+    @NSApplicationDelegateAdaptor private var appDelegate: CodeEditorAppDelegate
+    
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .environmentObject(appDelegate)
         }.commands {
             SidebarCommands()
+        }
+            .windowStyle(.hiddenTitleBar)
+            .windowToolbarStyle(.unified)
+            .handlesExternalEvents(matching: ["open"])
+        Settings {
+            SettingsView()
         }
     }
 }

--- a/CodeEdit/CodeEditorAppDelegate.swift
+++ b/CodeEdit/CodeEditorAppDelegate.swift
@@ -14,12 +14,6 @@ class CodeEditorAppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         }
     }
     
-    func closeFirstWindow() {
-        if let window = NSApplication.shared.windows.first {
-            window.close()
-        }
-    }
-    
     func newProjectURL() -> URL? {
         let dialog = NSOpenPanel()
 

--- a/CodeEdit/CodeEditorAppDelegate.swift
+++ b/CodeEdit/CodeEditorAppDelegate.swift
@@ -1,0 +1,38 @@
+//
+//  CodeEditorAppDelegate.swift
+//  CodeEdit
+//
+//  Created by Pavel Kasila on 12.03.22.
+//
+
+import SwiftUI
+
+class CodeEditorAppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        if let appearanceString = UserDefaults.standard.string(forKey: Appearances.appearanceStorageKey) {
+            Appearances(rawValue: appearanceString)?.applyAppearance()
+        }
+    }
+    
+    func closeFirstWindow() {
+        if let window = NSApplication.shared.windows.first {
+            window.close()
+        }
+    }
+    
+    func newProjectURL() -> URL? {
+        let dialog = NSOpenPanel()
+
+        dialog.title = "Open Folder"
+        dialog.showsResizeIndicator = true
+        dialog.showsHiddenFiles = false
+        dialog.canChooseFiles = false
+        dialog.canChooseDirectories = true
+
+        if (dialog.runModal() ==  NSApplication.ModalResponse.OK) {
+            return dialog.url
+        } else {
+            return nil
+        }
+    }
+}

--- a/CodeEdit/ContentView.swift
+++ b/CodeEdit/ContentView.swift
@@ -61,7 +61,7 @@ struct ContentView: View {
                         
                         // TODO: additional project initialization
                     } else {
-                        self.appDelegate.closeFirstWindow()
+                        NSApplication.shared.keyWindow?.close()
                     }
                 }
             }

--- a/CodeEdit/ContentView.swift
+++ b/CodeEdit/ContentView.swift
@@ -20,6 +20,9 @@ struct MainContentView: View {
 }
 
 struct ContentView: View {
+    @EnvironmentObject var appDelegate: CodeEditorAppDelegate
+    @SceneStorage("ContentView.path") private var path: String = ""
+    
     @State private var queryString = ""
     
     private let items = ["One", "Two", "Three", "Four", "Five"]
@@ -27,58 +30,84 @@ struct ContentView: View {
 
     var body: some View {
         NavigationView {
-            VStack {
-                List(selection: $selection) {
-                    NavigationLink(
-                        destination: MainContentView()
-                            .navigationTitle("Home")
-                            .navigationSubtitle("Dashboard"),
-                        label: {
-                            Image(systemName: "house")
-                                .foregroundColor(.secondary)
-                            Text("Home")
-                        }
-                    ).id("home")
-                    Section(header: Text("Items")) {
-                        ForEach(items, id: \.self) { item in
-                            NavigationLink(
-                                destination: Text("Item \(item)")
-                                    .navigationTitle("Item \(item)"),
-                                label: {
-                                    Image(systemName: "folder")
-                                        .foregroundColor(.secondary)
-                                    Text("Item \(item)")
-                                }
-                            )
-                        }
+            sidebar
+            
+            Text("Location: \(path)")
+        }
+        .toolbar {
+            ToolbarItem(placement: .navigation) {
+                Button(action: {}) {
+                    Image(systemName: "chevron.left")
+                }
+                .help("Back")
+            }
+            ToolbarItem(placement: .navigation) {
+                Button(action: {}){
+                    Image(systemName: "chevron.right")
+                }
+                .disabled(true)
+                .help("Forward")
+            }
+        }
+        .frame(minWidth: 800, minHeight: 600)
+        .onOpenURL { url in
+            path = url.path
+        }
+        .onAppear {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
+                if path == "" {
+                    if let url = self.appDelegate.newProjectURL() {
+                        self.path = url.path
+                        
+                        // TODO: additional project initialization
+                    } else {
+                        self.appDelegate.closeFirstWindow()
                     }
                 }
-                .listStyle(SidebarListStyle())
             }
-
-            .toolbar {
-            ToolbarItem(placement: .automatic) {
-                    Button(action: toggleSidebar, label: {
-                        Image(systemName: "sidebar.leading")
-                    }).help("Show/Hide Sidebar")
-                }
-                ToolbarItem(placement: .navigation) {
-                    Button(action: toggleSidebar, label: {
-                        Image(systemName: "chevron.left")
-                    }).help("Back")
-                }
-                ToolbarItem(placement: .navigation) {
-                    Button(action: toggleSidebar, label: {
-                        Image(systemName: "chevron.right")
-                    }).disabled(true).help("Fordward")
-                }
-
-            }
-            
         }
-        
-        
     }
+    
+    var sidebar: some View {
+        VStack {
+            List(selection: $selection) {
+                NavigationLink(
+                    destination: MainContentView()
+                        .navigationTitle("Home")
+                        .navigationSubtitle("Dashboard"),
+                    label: {
+                        Image(systemName: "house")
+                            .foregroundColor(.secondary)
+                        Text("Home")
+                    }
+                ).id("home")
+                Section(header: Text("Items")) {
+                    ForEach(items, id: \.self) { item in
+                        NavigationLink(
+                            destination: Text("Item \(item)")
+                                .navigationTitle("Item \(item)"),
+                            label: {
+                                Image(systemName: "folder")
+                                    .foregroundColor(.secondary)
+                                Text("Item \(item)")
+                            }
+                        )
+                    }
+                }
+            }
+            .listStyle(SidebarListStyle())
+        }
+        .frame(minWidth: 250)
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button(action: toggleSidebar) {
+                    Image(systemName: "sidebar.leading")
+                }
+                .help("Show/Hide Sidebar")
+            }
+        }
+    }
+    
     private func toggleSidebar() {
         #if os(iOS)
         #else

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>codeeditor</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/CodeEdit/Info.plist
+++ b/CodeEdit/Info.plist
@@ -9,7 +9,7 @@
 			<string>Editor</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>codeeditor</string>
+				<string>codeedit</string>
 			</array>
 		</dict>
 	</array>

--- a/CodeEdit/Settings/GeneralSettingsView.swift
+++ b/CodeEdit/Settings/GeneralSettingsView.swift
@@ -1,0 +1,63 @@
+//
+//  GeneralSettingsView.swift
+//  CodeEdit
+//
+//  Created by Pavel Kasila on 11.03.22.
+//
+
+import SwiftUI
+
+// MARK: - Data
+
+enum Appearances: String, CaseIterable, Hashable {
+    case system
+    case light
+    case dark
+    
+    func applyAppearance() {
+        switch self {
+        case .system:
+            NSApp.appearance = nil
+            break
+        case .dark:
+            NSApp.appearance = .init(named: .darkAqua)
+            break
+        case .light:
+            NSApp.appearance = .init(named: .aqua)
+            break
+        }
+    }
+    
+    static let appearanceStorageKey = "appearance"
+}
+
+// MARK: - View
+
+struct GeneralSettingsView: View {
+    @AppStorage(Appearances.appearanceStorageKey) var appearance: Appearances = Appearances.system
+    
+    var body: some View {
+        Form {
+            Picker("Appearance", selection: $appearance) {
+                Text("System")
+                    .tag(Appearances.system)
+                Divider()
+                Text("Light")
+                    .tag(Appearances.light)
+                Text("Dark")
+                    .tag(Appearances.dark)
+            }
+            .onChange(of: appearance) { tag in
+                tag.applyAppearance()
+            }
+        }
+        .padding()
+        
+    }
+}
+
+struct GeneralSettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        GeneralSettingsView()
+    }
+}

--- a/CodeEdit/Settings/SettingsView.swift
+++ b/CodeEdit/Settings/SettingsView.swift
@@ -1,0 +1,26 @@
+//
+//  SettingsView.swift
+//  CodeEdit
+//
+//  Created by Pavel Kasila on 11.03.22.
+//
+
+import SwiftUI
+
+struct SettingsView: View {
+    var body: some View {
+        TabView {
+            GeneralSettingsView()
+                .tabItem {
+                    Label("General", systemImage: "gearshape")
+                }
+        }
+        .frame(width: 450, height: 250)
+    }
+}
+
+struct SettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        SettingsView()
+    }
+}


### PR DESCRIPTION
## What's added?
* Project's folder opening on a new window
* Basic Settings (just General -> Appearances: user can specify system, light or dark appearance exclusively for CodeEditor)
* Now editor can be opened using URL: `codeedit://open[PATH_TO_FOLDER]`, e.g.: `codeedit://open/Users/pavelkasila/Developer/CodeEditor`